### PR TITLE
by default, only build the viewer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+viewer:
+	ocamlbuild -cflag -g -use-ocamlfind viewer.native
+
 all:
 	ocamlbuild -cflag -g -use-ocamlfind sim.native viewer.native
 	OCAMLRUNPARAM=b ./sim.native


### PR DESCRIPTION
Hello.

`make` failed for me with an error about `Lwt.current_id` in `sim.ml`.  The viewer builds OK on its own.

For anyone else that wants to try out the viewer, I thought it would be better to just build that by default.
