### PR TITLE
label threads that start off-screen

### DIFF
--- a/render.ml
+++ b/render.ml
@@ -200,6 +200,17 @@ let render top_thread =
         Cairo.move_to cr ~x:start_x ~y:(y_of_thread t -. 3.);
         Cairo.show_text cr msg
       );
+
+      (* show label on left margin if the thread starts off-screen *)
+      if start_x < -32. && end_x >= 32. then (
+        let msg =
+          match Thread.label t with
+          | None -> string_of_int (Thread.id t)
+          | Some label -> label in
+        thread_label cr;
+        Cairo.move_to cr ~x:4. ~y:(y_of_thread t -. 3.);
+        Cairo.show_text cr msg
+      );
     );
 
     true


### PR DESCRIPTION
I think it will help to see labels for threads that started before the current view.

Just an experiment; feel free to take it or leave it.
