### PR TITLE
Extend support for eio library

### DIFF
--- a/lib/mtv_ctf_loader.ml
+++ b/lib/mtv_ctf_loader.ml
@@ -21,6 +21,7 @@ let thread_type_of_int = function
   | 12 -> "On_any"
   | 13 -> "Ignore_result"
   | 14 -> "Async"
+  | 15 -> "Promise"
   | x -> Printf.eprintf "Warning: unknown thread type '%d'\n%!" x; "Unknown"
 
 let uuid = "\x05\x88\x3b\x8d\x52\x1a\x48\x7b\xb3\x97\x45\x6a\xb1\x50\x68\x0c"

--- a/lib/mtv_ctf_loader.ml
+++ b/lib/mtv_ctf_loader.ml
@@ -167,6 +167,10 @@ let from_bigarray stream_data =
               let value = read64 () |> Int64.to_int in
               let counter = read_string () in
               Counter_value (thread, counter, value)
+          | 12 ->
+              let reader = read_thread () in
+              let input = read_thread () in
+              Reads (reader, input, Read_resolved_later)
           | x -> error "Unknown event op %d" x in
         let event = {
           time = Int64.to_float time /. 1_000_000_000.;

--- a/lib/mtv_event.ml
+++ b/lib/mtv_event.ml
@@ -2,7 +2,7 @@ let printf = Printf.printf
 
 type thread = int
 
-type read_outcome = Read_resolved | Read_sleeping
+type read_outcome = Read_resolved | Read_resolved_later | Read_sleeping
 
 type op = 
   | Creates of thread * thread * string

--- a/lib/mtv_thread.ml
+++ b/lib/mtv_thread.ml
@@ -250,6 +250,14 @@ let of_events ?(simplify=true) events =
           | (_, Try_read, b2) :: rest when b == b2 -> rest  (* Simplify *)
           | all -> all in
         a.interactions <- (time, Read, b) :: interactions;
+    | Reads (a, b, Read_resolved_later) ->
+        let a = get_thread a in
+        let b = get_thread b in
+        let interactions =
+          match a.interactions with
+          | (_, Try_read, b2) :: rest when b == b2 -> rest  (* Simplify *)
+          | all -> all in
+        a.interactions <- (time, Read, b) :: interactions;
     | Reads (a, b, Read_sleeping) ->
         let a = get_thread a in
         let b = get_thread b in


### PR DESCRIPTION
This adds:
- A new thread type "promise" (eio separates fibres and threads).
- A read operation that doesn't also switch to the thread doing the read.