### PR TITLE
Support Cmdliner.1.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ setup.log
 setup.data
 example_html.byte
 examples/example_html.js
+_build

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
 examples/*.bin
 setup.log
-setup.data
-example_html.byte
-examples/example_html.js
 _build

--- a/gtk/main.ml
+++ b/gtk/main.ml
@@ -26,9 +26,8 @@ let () =
     `P "$(tname) views trace data from a file.";
     `P "mirage-trace-viewer-gtk trace.ctf";
   ] in
-  let info = Term.info ~doc ~man "mirage-trace-viewer-gtk" in
-  let term = Term.(ret (pure main $ Mtv_unix.trace_files)) in
-  match Term.eval (term, info) with
-  | `Ok () -> ()
-  | `Version | `Help -> ()
-  | `Error _ -> exit 1
+  let info = Cmd.info ~doc ~man "mirage-trace-viewer-gtk" in
+  let term = Term.(ret (const main $ Mtv_unix.trace_files)) in
+  match Cmd.eval (Cmd.v info term) with
+  | 0 -> ()
+  | _ -> exit 1

--- a/gtk/main.ml
+++ b/gtk/main.ml
@@ -28,6 +28,4 @@ let () =
   ] in
   let info = Cmd.info ~doc ~man "mirage-trace-viewer-gtk" in
   let term = Term.(ret (const main $ Mtv_unix.trace_files)) in
-  match Cmd.eval (Cmd.v info term) with
-  | 0 -> ()
-  | _ -> exit 1
+  exit @@ Cmd.eval (Cmd.v info term)

--- a/js-gen/main.ml
+++ b/js-gen/main.ml
@@ -26,6 +26,4 @@ let () =
   ] in
   let info = Cmd.info ~doc ~man "mirage-trace-viewer-js" in
   let term = Term.(ret (const main $ html_output $ Mtv_unix.trace_files)) in
-  match Cmd.eval (Cmd.v info term) with
-  | 0 -> ()
-  | _ -> exit 1
+  exit @@ Cmd.eval (Cmd.v info term)

--- a/js-gen/main.ml
+++ b/js-gen/main.ml
@@ -24,9 +24,8 @@ let () =
     `P "To generate HTML and JavaScript files in $(b,htdocs):";
     `P "mirage-trace-viewer-js --out=htdocs trace1.ctf trace2.ctf";
   ] in
-  let info = Term.info ~doc ~man "mirage-trace-viewer-js" in
-  let term = Term.(ret (pure main $ html_output $ Mtv_unix.trace_files)) in
-  match Term.eval (term, info) with
-  | `Ok () -> ()
-  | `Version | `Help -> ()
-  | `Error _ -> exit 1
+  let info = Cmd.info ~doc ~man "mirage-trace-viewer-js" in
+  let term = Term.(ret (const main $ html_output $ Mtv_unix.trace_files)) in
+  match Cmd.eval (Cmd.v info term) with
+  | 0 -> ()
+  | _ -> exit 1

--- a/js/html_viewer.ml
+++ b/js/html_viewer.ml
@@ -169,7 +169,7 @@ let attach ?(grab_focus=false) (c:Dom_html.canvasElement Js.t) v =
 
   let render () =
     if not (!render_queued) then (
-      Dom_html._requestAnimationFrame (Js.wrap_callback (fun _ev -> render_now ()));
+      let _id : Dom_html.animation_frame_request_id = Dom_html.window##requestAnimationFrame (Js.wrap_callback (fun _ev -> render_now ())) in 
       render_queued := true
     ) in
 

--- a/lib/dune
+++ b/lib/dune
@@ -1,4 +1,4 @@
 (library
   (name mirage_trace_viewer)
   (public_name mirage-trace-viewer)
-  (libraries itv-tree ocplib-endian.bigstring))
+  (libraries itv-tree ocplib-endian.bigstring unix))

--- a/lib/dune
+++ b/lib/dune
@@ -1,4 +1,4 @@
 (library
   (name mirage_trace_viewer)
   (public_name mirage-trace-viewer)
-  (libraries itv-tree ocplib-endian.bigstring unix))
+  (libraries itv-tree ocplib-endian.bigstring))

--- a/lib/mtv_ctf_loader.ml
+++ b/lib/mtv_ctf_loader.ml
@@ -192,10 +192,3 @@ let from_bigarray stream_data =
         (Printexc.to_string ex)
   );
   List.rev !events
-
-let from_channel ch =
-  let fd = Unix.descr_of_in_channel ch in
-  let size = Unix.((fstat fd).st_size) in
-  Unix.map_file fd char c_layout false [| size |]
-  |> Bigarray.array1_of_genarray
-  |> from_bigarray

--- a/lib/mtv_ctf_loader.mli
+++ b/lib/mtv_ctf_loader.mli
@@ -10,5 +10,4 @@ val packets : log_buffer -> packet list
 
 val packet_data : packet -> log_buffer
 
-val from_channel : in_channel -> Mtv_event.t list
 val from_bigarray : log_buffer -> Mtv_event.t list

--- a/unix/mtv_unix.ml
+++ b/unix/mtv_unix.ml
@@ -40,7 +40,7 @@ let parse_trace_filename trace_file =
   | "-" -> `Ok "-"
   | trace_file -> fst Arg.non_dir_file trace_file
 
-let input_file : (_ Arg.converter) = (parse_trace_filename, Format.pp_print_string)
+let input_file : (_ Arg.conv) = (parse_trace_filename, Format.pp_print_string)
 
 let trace_files =
   let doc = "The CTF-format trace file from which to load the trace data." in


### PR DESCRIPTION
This PR makes mirage-trace-viewer compatible with the latest cmdliner (and js_of_ocaml which was a single change) which is useful when working with OCaml 5 and [eio](https://github.com/ocaml-multicore/eio) where most people will be using a fairly up to date opam-repository. 

One thing I noticed was the `from_channel` function in the core `mirage-trace-viewer` library which depends on the `Unix` module. Should that be moved to `mirage-trace-viewer.unix` otherwise iiuc the latest compiler/dune requires the `unix` dependency to made explicit?