### PR TITLE
Support eio runtime events

### DIFF
--- a/eio/dune
+++ b/eio/dune
@@ -1,0 +1,4 @@
+(library
+ (name mirage_trace_viewer_eio)
+ (public_name mirage-trace-viewer.eio)
+ (libraries runtime_events eio mirage-trace-viewer))

--- a/eio/mirage_trace_viewer_eio.ml
+++ b/eio/mirage_trace_viewer_eio.ml
@@ -1,0 +1,92 @@
+
+open Mirage_trace_viewer
+
+module Ctf = Eio.Private.Ctf
+
+let current_thread = ref (-1)
+
+let to_time timestamp =
+  let t= Runtime_events.Timestamp.to_int64 timestamp in
+  Int64.to_float t /. 1_000_000_000.
+
+let id_event_callback ~add _domain_id timestamp user_event ((id : Ctf.id), value) =
+  match Runtime_events.User.tag user_event, value with
+  | Ctf.Created, e ->
+    add timestamp (Mtv_event.Creates (!current_thread, (id :> int), Ctf.event_to_string e))
+  | _ -> ()
+
+let id_callback ~add _domain_id timestamp user_event id =
+  match Runtime_events.User.tag user_event with
+  | Ctf.Switch ->
+    current_thread := (id :> int);
+    add timestamp (Mtv_event.Switch (id :> int) )
+  | Ctf.Resolved ->
+    add timestamp (Mtv_event.Resolves (!current_thread, (id :> int), None) )
+  | _ -> ()
+
+let unit_callback ~add _domain_id timestamp user_event () =
+  match Runtime_events.User.tag user_event with
+  | Ctf.Suspend ->
+    current_thread := -1;
+    add timestamp (Mtv_event.Switch (-1) )
+  | _ -> ()
+
+let id_label_callback ~add _domain_id timestamp user_event ((id : Ctf.id), label) =
+  match Runtime_events.User.tag user_event with
+  | Ctf.Label ->
+    add timestamp (Mtv_event.Label ((id :> int), label) )
+  | Ctf.Failed ->
+    add timestamp (Mtv_event.Resolves (!current_thread, (id :> int), Some label) )
+  | Ctf.Increase ->
+    add timestamp (Mtv_event.Increases (!current_thread, label, (id :> int)) )
+  | Ctf.Value ->
+    add timestamp (Mtv_event.Counter_value (!current_thread, label, (id :> int)) )
+  | _ -> ()
+
+let two_ids_callback ~add _domain_id timestamp user_event ((id1 : Ctf.id), (id2 : Ctf.id)) =
+  match Runtime_events.User.tag user_event with
+  | Ctf.Signal ->
+    add timestamp (Mtv_event.Signals (((id1 :> int), (id2 :> int))))
+  | _ -> ()
+
+let gc_begin = ref 0L
+
+let runtime_begin _ t phase =
+  match phase with
+  | Runtime_events.EV_MINOR | Runtime_events.EV_MAJOR ->
+    gc_begin := (Runtime_events.Timestamp.to_int64 t)
+  | _ -> ()
+
+let runtime_end ~add _ t phase =
+  match phase with
+  | Runtime_events.EV_MINOR | Runtime_events.EV_MAJOR ->
+    let ev = if phase = EV_MINOR then Mtv_event.Minor else Major in
+    let duration = Int64.sub (Runtime_events.Timestamp.to_int64 t) !gc_begin in
+    add t (Mtv_event.Gc (Int64.to_float duration /. 1_000_000_000., ev))
+  | _ -> ()
+
+let load_runtime_events path =
+  let dir = Filename.dirname path in
+  let file = Filename.basename path in
+  let pid = String.split_on_char '.' file |> List.hd |> int_of_string in
+  let cursor = Runtime_events.create_cursor (Some (dir, pid)) in
+
+  let events = ref [] in
+  let add timestamp op =
+    events := { Mtv_event.time = to_time timestamp; op} :: !events
+  in
+  let callback =
+    let open Runtime_events.Callbacks in
+    create
+      ~runtime_begin
+      ~runtime_end:(runtime_end ~add) ()
+    |> add_user_event Ctf.created_type (id_event_callback ~add)
+    |> add_user_event Runtime_events.Type.int (id_callback ~add)
+    |> add_user_event Runtime_events.Type.unit (unit_callback ~add)
+    |> add_user_event Ctf.labelled_type (id_label_callback ~add)
+    |> add_user_event Ctf.two_ids_type (two_ids_callback ~add)
+  in
+  while Runtime_events.read_poll cursor callback (None) > 0 do
+    ()
+  done;
+  List.rev !events

--- a/eio/mirage_trace_viewer_eio.mli
+++ b/eio/mirage_trace_viewer_eio.mli
@@ -1,0 +1,3 @@
+open Mirage_trace_viewer
+
+val load_runtime_events : string -> Mtv_event.t list

--- a/gtk/dune
+++ b/gtk/dune
@@ -1,5 +1,14 @@
 (executable
-  (name main)
-  (public_name mirage-trace-viewer-gtk)
-  (package mirage-trace-viewer-gtk)
-  (libraries mirage-trace-viewer mirage-trace-viewer.unix lablgtk2 cairo2-gtk cairo2 lwt lwt.unix str))
+ (name main)
+ (public_name mirage-trace-viewer-gtk)
+ (package mirage-trace-viewer-gtk)
+ (libraries
+  mirage-trace-viewer
+  mirage-trace-viewer.unix
+  mirage-trace-viewer.eio
+  lablgtk2
+  cairo2-gtk
+  cairo2
+  lwt
+  lwt.unix
+  str))

--- a/gtk/main.ml
+++ b/gtk/main.ml
@@ -5,8 +5,9 @@ open Mirage_trace_viewer
 let main paths =
   try
     GMain.init () |> ignore;
-    paths |> List.iter (fun path ->
-        let vat = Mtv_unix.load path |> Mtv_ctf_loader.from_bigarray |> Mtv_thread.of_events in
+    paths |> List.iter (fun (path : Mtv_unix.source) ->
+        let events = Mirage_trace_viewer_eio.load_runtime_events (path :> string) in
+        let vat = events |> Mtv_thread.of_events in
         let win = Gtk_viewer.make ~name:(path :> string) vat in
         ignore (win#connect#destroy ~callback:(fun _ ->
             (* todo: only quit when last window is closed *)

--- a/lib/mtv_ctf_loader.ml
+++ b/lib/mtv_ctf_loader.ml
@@ -155,7 +155,7 @@ let from_bigarray stream_data =
               Switch thread
           | 8 ->
               let duration = read64 () in
-              Gc (Int64.to_float duration /. 1_000_000_000.)
+              Gc (Int64.to_float duration /. 1_000_000_000., Unknown)
           | 9 ->
               let recv = read_thread () in
               let sender = read_thread () in

--- a/lib/mtv_event.ml
+++ b/lib/mtv_event.ml
@@ -4,14 +4,16 @@ type thread = int
 
 type read_outcome = Read_resolved | Read_resolved_later | Read_sleeping
 
-type op = 
+type gc_kind = Minor | Major | Unknown
+
+type op =
   | Creates of thread * thread * string
   | Reads of thread * thread * read_outcome
   | Resolves of thread * thread * string option
   | Becomes of thread * thread
   | Label of thread * string
   | Switch of thread
-  | Gc of float
+  | Gc of float * gc_kind
   | Increases of thread * string * int    (* Deprecated; use Counter_value instead *)
   | Counter_value of thread * string * int
   | Signals_and_switches of thread * thread

--- a/lib/mtv_thread.ml
+++ b/lib/mtv_thread.ml
@@ -34,7 +34,7 @@ type mutable_counter = {
 
 type vat = {
   top_thread : t;
-  mutable gc : (time * time) list;
+  mutable gc : (time * time * Mtv_event.gc_kind) list;
   mutable counters : Mtv_counter.t list;
 }
 
@@ -284,8 +284,8 @@ let of_events ?(simplify=true) events =
         )
     | Switch a ->
         switch time (Some (get_thread a))
-    | Gc duration ->
-        vat.gc <- (time -. duration, time) :: vat.gc
+    | Gc (duration, kind) ->
+        vat.gc <- (time -. duration, time, kind) :: vat.gc
     | Increases (a, counter, amount) ->
         let c = get_counter counter in
         let new_value = counter_value c + amount in

--- a/lib/mtv_thread.mli
+++ b/lib/mtv_thread.mli
@@ -10,7 +10,7 @@ type time = float
 type interaction = Resolve | Read | Try_read | Signal
 
 val top_thread : vat -> t
-val gc_periods : vat -> (time * time) list
+val gc_periods : vat -> (time * time * Mtv_event.gc_kind) list
 
 val thread_type : t -> string
 


### PR DESCRIPTION
_On top of https://github.com/TheLortex/eio/tree/runtime-events (which is a rebase of https://github.com/patricoferris/eio/tree/runtime-events)_

When eio emits events using the custom events API, mirage-trace-viewer will be able to consume them using this PR. 
The PR is **incomplete**, a command line option is needed to switch between the two formats (ctf / runtime events) (or a separate binary), both for the js and gtk versions.

I have also added support for the GC runtime events, now GC phases are also displayed:

 
![image](https://user-images.githubusercontent.com/966015/217559947-f3be38f6-0afe-4622-a8cb-afa82e7596f6.png)
